### PR TITLE
fix: tests using wrong int type

### DIFF
--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -28,9 +28,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, defaultInitialOffset, cfg.InitialOffset)
 	assert.Equal(t, defaultSessionTimeout, cfg.SessionTimeout)
 	assert.Equal(t, defaultHeartbeatInterval, cfg.HeartbeatInterval)
-	assert.Equal(t, defaultMinFetchSize, cfg.MinFetchSize)
-	assert.Equal(t, defaultDefaultFetchSize, cfg.DefaultFetchSize)
-	assert.Equal(t, defaultMaxFetchSize, cfg.MaxFetchSize)
+	assert.Equal(t, int32(defaultMinFetchSize), int32(cfg.MinFetchSize))
+	assert.Equal(t, int32(defaultDefaultFetchSize), int32(cfg.DefaultFetchSize))
+	assert.Equal(t, int32(defaultMaxFetchSize), int32(cfg.MaxFetchSize))
 }
 
 func TestCreateTracesReceiver(t *testing.T) {


### PR DESCRIPTION
need to specify `int32` for these, Go assumes `int` if not specified